### PR TITLE
feat: add Kubernetes manifests and deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Backend REST API professionnel construit avec NestJS, PostgreSQL, et des pratiqu
 - [Installation](#-installation)
 - [Configuration](#-configuration)
 - [Utilisation](#-utilisation)
+- [Déploiement](#-déploiement)
 - [Tests](#-tests)
 - [CI/CD](#-cicd)
 - [API Documentation](#-api-documentation)
@@ -45,7 +46,10 @@ Backend REST API professionnel construit avec NestJS, PostgreSQL, et des pratiqu
 ### DevOps
 - **Docker** - Containerisation
 - **Docker Compose** - Orchestration locale
+- **Kubernetes** - Orchestration production
 - **GitHub Actions** - CI/CD automatisé
+- **SAST** - CodeQL pour analyse statique
+- **DAST** - OWASP ZAP pour tests dynamiques
 - **ESLint & Prettier** - Qualité de code
 
 ## 🏗 Architecture
@@ -61,6 +65,11 @@ taskmanager/
 │   ├── app.module.ts    # Module principal
 │   └── main.ts          # Point d'entrée
 ├── test/                # Tests unitaires et d'intégration
+├── k8s/                 # Manifests Kubernetes
+│   ├── namespace.yaml
+│   ├── postgres-*.yaml
+│   ├── app-*.yaml
+│   └── README.md
 ├── .github/workflows/   # CI/CD pipelines
 ├── Dockerfile           # Image Docker optimisée
 └── docker-compose.yml   # Stack complète (API + PostgreSQL)
@@ -139,6 +148,49 @@ npm run start:prod
 - `GET /metrics` - Métriques de l'application
 - `GET /health` - Health check
 
+## 🚀 Déploiement
+
+### Docker Compose (Local/Staging)
+
+```bash
+# Démarrer tous les services
+docker compose up -d
+
+# Vérifier le statut
+docker compose ps
+
+# Voir les logs
+docker compose logs -f
+
+# Arrêter les services
+docker compose down
+```
+
+### Kubernetes (Production)
+
+Le projet inclut des manifests Kubernetes complets dans le dossier `k8s/`.
+
+```bash
+# Déployer sur Kubernetes
+kubectl apply -f k8s/
+
+# Vérifier le déploiement
+kubectl get all -n user-platform
+
+# Accéder aux logs
+kubectl logs -f deployment/user-platform-api -n user-platform
+```
+
+**Architecture Kubernetes:**
+- **3 replicas** de l'API pour haute disponibilité
+- **PostgreSQL** avec PersistentVolumeClaim (5Gi)
+- **LoadBalancer** pour l'accès externe
+- **ConfigMap** et **Secret** pour la configuration
+- **Health checks** (liveness + readiness probes)
+- **Resource limits** (CPU: 250m-1, Memory: 256Mi-512Mi)
+
+📖 Voir [k8s/README.md](k8s/README.md) pour le guide complet de déploiement Kubernetes.
+
 ## 🧪 Tests
 
 ```bash
@@ -173,19 +225,29 @@ Le workflow [cicd.yml](.github/workflows/cicd.yml) exécute:
    - npm audit pour les vulnérabilités
    - Vérification des dépendances obsolètes
 
-3. **Build Application**
+3. **SAST - Static Application Security Testing**
+   - CodeQL analysis (JavaScript/TypeScript)
+   - Détection de vulnérabilités dans le code source
+   - Intégration avec GitHub Security
+
+4. **Build Application**
    - Build sur Node.js 18, 20, 21
    - Upload des artifacts de build
 
-4. **Unit Tests & Coverage**
+5. **Unit Tests & Coverage**
    - Exécution de tous les tests
    - Génération du rapport de couverture
 
-5. **Environment Configuration**
+6. **DAST - Dynamic Application Security Testing**
+   - OWASP ZAP baseline scan
+   - Test de sécurité sur application en cours d'exécution
+   - Génération de rapports (HTML, JSON, Markdown)
+
+7. **Environment Configuration**
    - Validation des fichiers de config
    - Vérification Docker Compose
 
-6. **CI Pipeline Success**
+8. **CI Pipeline Success**
    - Récapitulatif de tous les checks
 
 ### Badges de statut

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,246 @@
+# Kubernetes Deployment Guide
+
+This directory contains Kubernetes manifests for deploying the User Platform API.
+
+## 📋 Architecture
+
+```
+┌─────────────────────────────────────────┐
+│         LoadBalancer Service            │
+│          (user-platform-api)            │
+│              Port 80 → 3000             │
+└─────────────────┬───────────────────────┘
+                  │
+      ┌───────────┴──────────┬───────────┐
+      │                      │           │
+┌─────▼──────┐   ┌──────▼──────┐   ┌────▼──────┐
+│   Pod 1    │   │   Pod 2     │   │   Pod 3   │
+│   API      │   │   API       │   │   API     │
+│ (replica)  │   │ (replica)   │   │ (replica) │
+└─────┬──────┘   └──────┬──────┘   └────┬──────┘
+      │                 │                │
+      └─────────────────┼────────────────┘
+                        │
+              ┌─────────▼─────────┐
+              │ ClusterIP Service │
+              │    (postgres)     │
+              │    Port 5432      │
+              └─────────┬─────────┘
+                        │
+                  ┌─────▼──────┐
+                  │ PostgreSQL │
+                  │    Pod     │
+                  │   + PVC    │
+                  └────────────┘
+```
+
+## 🚀 Deployment Steps
+
+### Prerequisites
+
+- Kubernetes cluster (v1.24+)
+- kubectl configured
+- Docker image built
+
+### 1. Build Docker Image
+
+```bash
+# Build the application image
+docker build -t user-platform-api:latest .
+
+# Tag for your registry (optional)
+docker tag user-platform-api:latest your-registry/user-platform-api:latest
+docker push your-registry/user-platform-api:latest
+```
+
+### 2. Update Secrets (IMPORTANT!)
+
+Edit `app-secret.yaml` and replace placeholder values:
+
+```bash
+kubectl create secret generic app-secret \
+  --from-literal=db-password='your_secure_password' \
+  --from-literal=metrics-api-key='your_api_key' \
+  -n user-platform --dry-run=client -o yaml > app-secret.yaml
+```
+
+### 3. Deploy to Kubernetes
+
+```bash
+# Create namespace
+kubectl apply -f namespace.yaml
+
+# Deploy PostgreSQL
+kubectl apply -f postgres-pvc.yaml
+kubectl apply -f postgres-deployment.yaml
+kubectl apply -f postgres-service.yaml
+
+# Wait for PostgreSQL to be ready
+kubectl wait --for=condition=ready pod -l app=postgres -n user-platform --timeout=120s
+
+# Deploy Application
+kubectl apply -f app-configmap.yaml
+kubectl apply -f app-secret.yaml
+kubectl apply -f app-deployment.yaml
+kubectl apply -f app-service.yaml
+
+# Wait for application to be ready
+kubectl wait --for=condition=ready pod -l app=user-platform-api -n user-platform --timeout=120s
+```
+
+### 4. Deploy All at Once
+
+```bash
+# Deploy everything in order
+kubectl apply -f k8s/
+```
+
+## 🔍 Verify Deployment
+
+```bash
+# Check all resources
+kubectl get all -n user-platform
+
+# Check pods
+kubectl get pods -n user-platform
+
+# Check services
+kubectl get svc -n user-platform
+
+# Check logs
+kubectl logs -f deployment/user-platform-api -n user-platform
+
+# Check PostgreSQL logs
+kubectl logs -f deployment/postgres -n user-platform
+```
+
+## 🌐 Access the API
+
+```bash
+# Get the LoadBalancer IP/hostname
+kubectl get svc user-platform-api -n user-platform
+
+# Test the API
+EXTERNAL_IP=$(kubectl get svc user-platform-api -n user-platform -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+curl http://$EXTERNAL_IP/health
+curl http://$EXTERNAL_IP/users
+```
+
+## 🔧 Configuration
+
+### Scaling
+
+```bash
+# Scale up replicas
+kubectl scale deployment user-platform-api --replicas=5 -n user-platform
+
+# Autoscaling (HPA)
+kubectl autoscale deployment user-platform-api \
+  --cpu-percent=70 \
+  --min=3 \
+  --max=10 \
+  -n user-platform
+```
+
+### Update Image
+
+```bash
+# Update deployment with new image
+kubectl set image deployment/user-platform-api \
+  api=user-platform-api:v2.0.0 \
+  -n user-platform
+
+# Check rollout status
+kubectl rollout status deployment/user-platform-api -n user-platform
+
+# Rollback if needed
+kubectl rollout undo deployment/user-platform-api -n user-platform
+```
+
+### Resource Management
+
+```bash
+# View resource usage
+kubectl top pods -n user-platform
+kubectl top nodes
+
+# Describe deployment
+kubectl describe deployment user-platform-api -n user-platform
+```
+
+## 🐛 Troubleshooting
+
+### Pods Not Starting
+
+```bash
+# Check pod events
+kubectl describe pod <pod-name> -n user-platform
+
+# Check logs
+kubectl logs <pod-name> -n user-platform
+
+# Check previous logs (if crashed)
+kubectl logs <pod-name> -n user-platform --previous
+```
+
+### Database Connection Issues
+
+```bash
+# Check PostgreSQL is running
+kubectl get pods -l app=postgres -n user-platform
+
+# Test connection from API pod
+kubectl exec -it <api-pod-name> -n user-platform -- sh
+apk add postgresql-client
+psql -h postgres -U postgres -d user_platform_db
+```
+
+### Check ConfigMap and Secrets
+
+```bash
+# View ConfigMap
+kubectl get configmap app-config -n user-platform -o yaml
+
+# Check Secret (base64 encoded)
+kubectl get secret app-secret -n user-platform -o yaml
+```
+
+## 🗑️ Cleanup
+
+```bash
+# Delete all resources
+kubectl delete -f k8s/
+
+# Or delete namespace (removes everything)
+kubectl delete namespace user-platform
+```
+
+## 📊 Resource Specifications
+
+### PostgreSQL
+
+- **Replicas**: 1 (StatefulSet recommended for production)
+- **CPU**: 250m - 1 core
+- **Memory**: 256Mi - 512Mi
+- **Storage**: 5Gi PVC
+
+### API Application
+
+- **Replicas**: 3 (horizontal scaling)
+- **CPU**: 250m - 1 core per pod
+- **Memory**: 256Mi - 512Mi per pod
+- **Strategy**: RollingUpdate (zero-downtime)
+
+## 🔐 Security Notes
+
+1. **Secrets**: Update `app-secret.yaml` with secure values before deployment
+2. **Network Policies**: Consider adding NetworkPolicy for pod-to-pod communication
+3. **RBAC**: Implement Role-Based Access Control for production
+4. **Image Security**: Use private registry and scan images for vulnerabilities
+5. **TLS**: Add Ingress with TLS certificates for HTTPS
+
+## 📚 Additional Resources
+
+- [Kubernetes Documentation](https://kubernetes.io/docs/)
+- [kubectl Cheat Sheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/)
+- [Best Practices](https://kubernetes.io/docs/concepts/configuration/overview/)

--- a/k8s/app-configmap.yaml
+++ b/k8s/app-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: user-platform
+  labels:
+    app: user-platform-api
+data:
+  NODE_ENV: "production"
+  PORT: "3000"
+  DB_HOST: "postgres"
+  DB_PORT: "5432"
+  DB_USERNAME: "postgres"
+  DB_DATABASE: "user_platform_db"
+  TZ: "Europe/Paris"

--- a/k8s/app-deployment.yaml
+++ b/k8s/app-deployment.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: user-platform-api
+  namespace: user-platform
+  labels:
+    app: user-platform-api
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: user-platform-api
+  template:
+    metadata:
+      labels:
+        app: user-platform-api
+    spec:
+      containers:
+      - name: api
+        image: user-platform-api:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3000
+          name: http
+        env:
+        - name: NODE_ENV
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: NODE_ENV
+        - name: PORT
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: PORT
+        - name: DB_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: DB_HOST
+        - name: DB_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: DB_PORT
+        - name: DB_USERNAME
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: DB_USERNAME
+        - name: DB_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: DB_DATABASE
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: app-secret
+              key: db-password
+        - name: METRICS_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: app-secret
+              key: metrics-api-key
+        - name: TZ
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: TZ
+        resources:
+          limits:
+            cpu: "1"
+            memory: "512Mi"
+          requests:
+            cpu: "250m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3

--- a/k8s/app-secret.yaml
+++ b/k8s/app-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secret
+  namespace: user-platform
+  labels:
+    app: user-platform-api
+type: Opaque
+stringData:
+  # IMPORTANT: Change these values in production!
+  db-password: "your_secure_password_here"
+  metrics-api-key: "your_metrics_api_key_here"

--- a/k8s/app-service.yaml
+++ b/k8s/app-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-platform-api
+  namespace: user-platform
+  labels:
+    app: user-platform-api
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 3000
+    protocol: TCP
+    name: http
+  selector:
+    app: user-platform-api

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: user-platform
+  labels:
+    name: user-platform
+    environment: production

--- a/k8s/postgres-deployment.yaml
+++ b/k8s/postgres-deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: user-platform
+  labels:
+    app: postgres
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:16-alpine
+        ports:
+        - containerPort: 5432
+          name: postgres
+        env:
+        - name: POSTGRES_USER
+          value: "postgres"
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: app-secret
+              key: db-password
+        - name: POSTGRES_DB
+          value: "user_platform_db"
+        - name: TZ
+          value: "Europe/Paris"
+        volumeMounts:
+        - name: postgres-storage
+          mountPath: /var/lib/postgresql/data
+        resources:
+          limits:
+            cpu: "1"
+            memory: "512Mi"
+          requests:
+            cpu: "250m"
+            memory: "256Mi"
+        livenessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -U
+            - postgres
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -U
+            - postgres
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+      volumes:
+      - name: postgres-storage
+        persistentVolumeClaim:
+          claimName: postgres-pvc

--- a/k8s/postgres-pvc.yaml
+++ b/k8s/postgres-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  namespace: user-platform
+  labels:
+    app: postgres
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: standard

--- a/k8s/postgres-service.yaml
+++ b/k8s/postgres-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: user-platform
+  labels:
+    app: postgres
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5432
+    targetPort: 5432
+    protocol: TCP
+    name: postgres
+  selector:
+    app: postgres


### PR DESCRIPTION
Issue #12 - Add Kubernetes support for production deployment

**Kubernetes Manifests:**
- namespace.yaml: user-platform namespace
- postgres-pvc.yaml: 5Gi persistent storage
- postgres-deployment.yaml: PostgreSQL with health checks
- postgres-service.yaml: ClusterIP service
- app-configmap.yaml: Environment configuration
- app-secret.yaml: Sensitive data (passwords, API keys)
- app-deployment.yaml: 3 replicas with rolling update
- app-service.yaml: LoadBalancer for external access

**Features:**
- High availability with 3 API replicas
- Resource limits (CPU: 250m-1, Memory: 256Mi-512Mi)
- Liveness and readiness probes
- Rolling update strategy
- PersistentVolumeClaim for PostgreSQL
- ConfigMap/Secret separation

**Documentation:**
- k8s/README.md: Complete deployment guide
- Updated main README with Kubernetes section
- Added SAST/DAST to CI/CD documentation